### PR TITLE
I2 login user after the LTI launch

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -9,7 +9,8 @@ MYSQL_PORT=3306
 # Django settings
 # python manage.py shell -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())"
 SECRET_KEY='you-django-key' 
-DEBUG=True
+DJANGO_DEBUG=True
+DJANGO_LOG_LEVEL=DEBUG
 TZ=America/Detroit
 CSRF_TRUSTED_ORIGINS=https://*.instructure.com,https://*.umich.edu
 ALLOWED_HOSTS=.loophole.site,.ngrok-free.app, 127.0.0.1, localhost

--- a/.env.sample
+++ b/.env.sample
@@ -12,4 +12,4 @@ SECRET_KEY='you-django-key'
 DEBUG=True
 TZ=America/Detroit
 CSRF_TRUSTED_ORIGINS=https://*.instructure.com,https://*.umich.edu
-ALLOWED_HOSTS=.loophole.site,.ngrok-free.app
+ALLOWED_HOSTS=.loophole.site,.ngrok-free.app, 127.0.0.1, localhost

--- a/README.md
+++ b/README.md
@@ -27,11 +27,10 @@ mostly just MySQL information as well as locations of other configuration files.
     docker compose up
     ```
 
-1.
+1. generate Django secret using below command
 ```sh
 python manage.py shell -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())"
 ```
-1.
 
 ## LTI install
 1. Need to run this command once docker container is up in order for LTI to work. This is important step otherwise the LTI tool launch won't happen
@@ -40,7 +39,7 @@ python manage.py shell -c "from django.core.management.utils import get_random_s
   "python manage.py rotate_keys" 
 ```
 2. use the `setup/lti-config.json` for registing the LTI tool. Replace all the `{app-hostname}` with your web proxy url.  
-3. Create superuser via using `python manage.py createsuperuser', need to run a proxy like loophole or ngrok for LTI installation and login with that user. Go to https://<url>/admin/. 
+3. Create superuser via using `python manage.py createsuperuser', need to run a proxy like loophole or ngrok for LTI installation and login with that user. Go to https://{app-hostname}/admin/. 
 4. Goto `LTIRegistration` to configure an LTI tool from admin console. This will create the `uuid` automatically. Hold on to that value and update the `OpenID Connect Initiation Url` in the LTI tool registration from Canvas with this id. 
    ` for Eg: https://clrt-local.loophole.site/init/0b54a91b-cac6-4c96-ba1e/`
 5. Configure the LTI configuration from CLRT tool going to admin again. Give the following value. Note: `<canvas-instance>: ['canvas.test', 'canvas.beta']`

--- a/README.md
+++ b/README.md
@@ -38,11 +38,15 @@ python manage.py shell -c "from django.core.management.utils import get_random_s
  docker exec -it clrt_web /bin/bash -c \
   "python manage.py rotate_keys" 
 ```
-2. use the `setup/lti-config.json` for registing the LTI tool. Replace all the `{app-hostname}` with your web proxy url.  
-3. Create superuser via using `python manage.py createsuperuser', need to run a proxy like loophole or ngrok for LTI installation and login with that user. Go to https://{app-hostname}/admin/. 
-4. Goto `LTIRegistration` to configure an LTI tool from admin console. This will create the `uuid` automatically. Hold on to that value and update the `OpenID Connect Initiation Url` in the LTI tool registration from Canvas with this id. 
+
+2. Create superuser via using `python manage.py createsuperuser', need to run a proxy like loophole or ngrok for LTI installation and login with that user. Go to https://{app-hostname}/admin/.  
+3. Go to Canvas instance, choose Developer Keys in admin site
+4. Add LTI Key
+5. Choose Paste JSON method
+6. Goto `LTIRegistration` to configure an LTI tool from admin console. This will create the `uuid` automatically. Hold on to that value and update the `OpenID Connect Initiation Url` in the LTI tool registration from Canvas with this id. 
    ` for Eg: https://clrt-local.loophole.site/init/0b54a91b-cac6-4c96-ba1e/`
-5. Configure the LTI configuration from CLRT tool going to admin again. Give the following value. Note: `<canvas-instance>: ['canvas.test', 'canvas.beta']`
+7. use the `setup/lti-config.json` for registing the LTI tool. Replace all the `{app-hostname}` with your web proxy url and <uuid:lti-registration> with UUID value from LTI tool registration.  
+8. Configure the LTI configuration from CLRT tool going to admin again. Give the following value. Note: `<canvas-instance>: ['canvas.test', 'canvas.beta']`
       1. Name: any name
       2. Issuer: https://<canvas-instance>.instructure.com
       2. Client ID: (get this from Platform)
@@ -50,8 +54,8 @@ python manage.py shell -c "from django.core.management.utils import get_random_s
       4. Access token URL: https://<canvas-instance>.instructure.com/login/oauth2/token
       5. Keyset URL: https://<canvas-instance>.instructure.com/api/lti/security/jwks
       6. DEPLOYMENT ID: get this as it is described the step 7 and paste 
-6. Save
-7. Go to the Canvas(platform) add the LTI tool at account/course level and copy the deployment id by clicking the setting button next to it.
+9. Save
+10. Go to the Canvas(platform) add the LTI tool at account/course level and copy the deployment id by clicking the setting button next to it.
 
 ## Make a user superuser
 1. go to the `auth_user` table and set `is_superuser` and `is_staff` to `1` or `true` this will give the logged user access to admin interface

--- a/README.md
+++ b/README.md
@@ -53,5 +53,8 @@ python manage.py shell -c "from django.core.management.utils import get_random_s
 6. Save
 7. Go to the Canvas(platform) and install the tool at account/cource and copy the deployment id
 
+## Make a user superuser
+1. go to the `auth_user` table and set `is_superuser` and `is_staff` to `1` or `true` this will give the logged user access to admin interface
+
 
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ python manage.py shell -c "from django.core.management.utils import get_random_s
       5. Keyset URL: https://<canvas-instance>.instructure.com/api/lti/security/jwks
       6. DEPLOYMENT ID: get this as it is described the step 7 and paste 
 6. Save
-7. Go to the Canvas(platform) and install the tool at account/cource and copy the deployment id
+7. Go to the Canvas(platform) add the LTI tool at account/course level and copy the deployment id by clicking the setting button next to it.
 
 ## Make a user superuser
 1. go to the `auth_user` table and set `is_superuser` and `is_staff` to `1` or `true` this will give the logged user access to admin interface

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ python manage.py shell -c "from django.core.management.utils import get_random_s
    ` for Eg: https://clrt-local.loophole.site/init/0b54a91b-cac6-4c96-ba1e/`
 5. Configure the LTI configuration from CLRT tool going to admin again. Give the following value. Note: `<canvas-instance>: ['canvas.test', 'canvas.beta']`
       1. Name: any name
+      2. Issuer: https://<canvas-instance>.instructure.com
       2. Client ID: (get this from Platform)
       3. Auth URL: https://<canvas-instance>.instructure.com/api/lti/authorize_redirect
       4. Access token URL: https://<canvas-instance>.instructure.com/login/oauth2/token

--- a/README.md
+++ b/README.md
@@ -1,18 +1,57 @@
 # canvas-lti-redirect-tool
 This is Canvas LTI redirect tool which use the CAI developed [LTI library](https://pypi.org/project/django-lti/)
 
-## Generating Django security key
+### Prerequisites
+
+To follow the instructions below, you will at minimum need the following:
+1. **[Docker Desktop](https://www.docker.com/products/docker-desktop/)**.
+1. **[Git](https://git-scm.com/downloads)**
+### Installation and Setup
+1. You need to web Proxy like Loophole or ngrok to run the application. Loophole offers custom domain
+    ```sh
+    loophole http 6000 --hostname <your-host>
+    ```
+1. Copy the `.env.sample` file as `.env`. 
+    ```sh
+    cp .env.sample .env
+1. Examine the `.env` file. It will have the suggested default environment variable settings,
+mostly just MySQL information as well as locations of other configuration files.
+
+1. Start the Docker build process (this will take some time).
+    ```sh
+    docker compose build
+    ```
+
+1. Start up the web server and database containers.
+    ```sh
+    docker compose up
+    ```
+
+1.
 ```sh
 python manage.py shell -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())"
 ```
+1.
 
 ## LTI install
-1. Need to run this command once in order for LTI to work
+1. Need to run this command once docker container is up in order for LTI to work. This is important step otherwise the LTI tool launch won't happen
 ```sh
  docker exec -it clrt_web /bin/bash -c \
   "python manage.py rotate_keys" 
-```  
-2. Create superuser via using `python manage.py createsuperuser', need to run a proxy like loophole or ngrok for LTI installation and login with that user.
-https://<url>/admin/
-4. Use `LTIRegistration` to configure an LTI tool
+```
+2. use the `setup/lti-config.json` for registing the LTI tool. Replace all the `{app-hostname}` with your web proxy url.  
+3. Create superuser via using `python manage.py createsuperuser', need to run a proxy like loophole or ngrok for LTI installation and login with that user. Go to https://<url>/admin/. 
+4. Goto `LTIRegistration` to configure an LTI tool from admin console. This will create the `uuid` automatically. Hold on to that value and update the `OpenID Connect Initiation Url` in the LTI tool registration from Canvas with this id. 
+   ` for Eg: https://clrt-local.loophole.site/init/0b54a91b-cac6-4c96-ba1e/`
+5. Configure the LTI configuration from CLRT tool going to admin again. Give the following value. Note: `<canvas-instance>: ['canvas.test', 'canvas.beta']`
+      1. Name: any name
+      2. Client ID: (get this from Platform)
+      3. Auth URL: https://<canvas-instance>.instructure.com/api/lti/authorize_redirect
+      4. Access token URL: https://<canvas-instance>.instructure.com/login/oauth2/token
+      5. Keyset URL: https://<canvas-instance>.instructure.com/api/lti/security/jwks
+      6. DEPLOYMENT ID: get this as it is described the step 7 and paste 
+6. Save
+7. Go to the Canvas(platform) and install the tool at account/cource and copy the deployment id
+
+
 

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -32,6 +32,7 @@ print(CSRF_TRUSTED_ORIGINS)
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
+RANDOM_PASSWORD_DEFAULT_LENGTH = 32
 
 allowed_hosts = config('ALLOWED_HOSTS', '')
 ALLOWED_HOSTS = [host.strip() for host in allowed_hosts.split(',')]

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -10,14 +10,16 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/5.0/ref/settings/
 """
 
-import os
+import os, logging
 from pathlib import Path
 from decouple import config
 # from csp.constants import SELF, UNSAFE_INLINE
 
+logger = logging.getLogger(__name__)
+logging.basicConfig(level='INFO')
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
-print(BASE_DIR)
 
 
 # Quick-start development settings - unsuitable for production
@@ -27,11 +29,11 @@ SECRET_KEY = config('SECRET_KEY','123455')
 # Read the CSRF_TRUSTED_ORIGINS variable from the .env file
 csrf_trusted_origins = config('CSRF_TRUSTED_ORIGINS', '')
 CSRF_TRUSTED_ORIGINS = [origin.strip() for origin in csrf_trusted_origins.split(',')]
-print(CSRF_TRUSTED_ORIGINS)
 
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = config('DJANGO_DEBUG', default=False, cast=bool)
+print(DEBUG)
 RANDOM_PASSWORD_DEFAULT_LENGTH = 32
 
 allowed_hosts = config('ALLOWED_HOSTS', '')
@@ -79,6 +81,44 @@ STORAGES = {
         "BACKEND": 'whitenoise.storage.CompressedManifestStaticFilesStorage',
     },
 }
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        "generic": {
+            "format": "%(asctime)s [%(levelname)s] [%(filename)s:%(lineno)d] %(message)s",
+            "datefmt": "[%Y-%m-%d %H:%M:%S %z]",
+            "class": "logging.Formatter",
+        }
+    },
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+            'formatter': 'generic',
+        },
+    },
+    'loggers': {
+        'django': {
+            'handlers': ['console'],
+            'propagate': False,
+            'level': config('DJANGO_LOG_LEVEL', 'DEBUG'),
+        },
+        'rules': {
+            'handlers': ['console'],
+            'propagate': False,
+            'level': 'INFO',
+        },
+        '': {
+            'level': 'WARNING',
+            'handlers': ['console'],
+        },
+
+    },
+    'root': {
+        'level': 'INFO',
+        'handlers': ['console']
+    },
+}
 
 TEMPLATES = [
     {
@@ -86,6 +126,7 @@ TEMPLATES = [
         'DIRS': [os.path.join(BASE_DIR, "templates")],
         'APP_DIRS': True,
         'OPTIONS': {
+            'debug': DEBUG,
             'context_processors': [
                 'django.template.context_processors.debug',
                 'django.template.context_processors.request',

--- a/lti_redirect/static/home.css
+++ b/lti_redirect/static/home.css
@@ -12,29 +12,26 @@
 }
 
 .navbar a {
-  text-decoration: none;
   color: inherit;
 }
 
 .navbar-brand {
   font-size: 1.2em;
   font-weight: 600;
+  text-decoration: none;
 }
+.navbar-user{
+  font-size: 1em;
+  font-weight: 600;
+  padding-left: 30px;
 
+}
 .navbar-item {
-  font-variant: small-caps;
-  margin-left: 30px;
+  float: right;
+  text-decoration: underline;
 }
 
 .body-content {
   padding: 5px;
   font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-}
-input[name=message] {
-  width: 80%;
-}
-
-.message_list th,td {
-  text-align: left;
-  padding-right: 15px;
 }

--- a/lti_redirect/templates/error.html
+++ b/lti_redirect/templates/error.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8"/>
+    <title>{% block title %}{% endblock %}</title>
+    {% load static %}
+    <link rel="stylesheet" type="text/css" href="{% static 'home.css' %}"/>
+</head>
+
+<body>
+<p>Error occured during launch the Canvas LTI Redirect Tool</p>
+</body>
+</html>

--- a/lti_redirect/templates/home.html
+++ b/lti_redirect/templates/home.html
@@ -10,6 +10,12 @@
 <body>
 <div class="navbar">
     <a href="{% url 'home' %}" class="navbar-brand">LTI Redirect TOOL</a>
+    {% if user.is_authenticated and user.is_superuser %}
+    <a class="navbar-item" href="{% url 'admin:index' %}">Admin</a>
+    {% endif %}
+    {% if user.is_authenticated %}
+    <span class="navbar-user">{{ user.username }}</span>
+    {% endif %}
 </div>
 
 <div class="body-content">

--- a/lti_redirect/urls.py
+++ b/lti_redirect/urls.py
@@ -4,6 +4,7 @@ from lti_tool.views import jwks, OIDCLoginInitView
 from lti_redirect.views import ApplicationLaunchView
 urlpatterns = [
      path('', views.get_home_template, name = 'home'),
+     path('error', views.error, name="error" ),
 
      # LTI launch urls
     path(".well-known/jwks.json", jwks, name="jwks"),

--- a/setup/lti-config.json
+++ b/setup/lti-config.json
@@ -1,0 +1,43 @@
+{
+  "title": "Canvas LTI Redirect Tool",
+  "scopes": [],
+  "extensions": [
+      {
+          "domain": "{app-hostname}",
+          "platform": "canvas.instructure.com",
+          "settings": {
+              "platform": "canvas.instructure.com",
+              "placements": [
+                  {
+                      "placement": "course_navigation",
+                      "message_type": "LtiResourceLinkRequest",
+                      "target_link_uri": "https://{app-hostname}/ltilaunch"
+                  }
+              ]
+          },
+          "privacy_level": "public"
+      }
+  ],
+  "public_jwk": {},
+  "description": "This is canvas LTI redirect tool",
+  "custom_fields": {
+      "roles": "$Canvas.membership.roles",
+      "term_id": "$Canvas.term.id",
+      "login_id": "$Canvas.user.loginId",
+      "term_end": "$Canvas.term.endAt",
+      "course_id": "$Canvas.course.id",
+      "term_name": "$Canvas.term.name",
+      "canvas_url": "$Canvas.api.baseUrl",
+      "term_start": "$Canvas.term.startAt",
+      "redirect_url": "https://dev.dev.umgpt.umich.edu/",
+      "course_status": "$Canvas.course.workflowState",
+      "user_canvas_id": "$Canvas.user.id",
+      "course_account_name": "$Canvas.account.name",
+      "course_enroll_status": "$Canvas.enrollment.enrollmentState",
+      "course_sis_account_id": "$Canvas.course.sisSourceId",
+      "course_canvas_account_id": "$Canvas.account.id"
+  },
+  "public_jwk_url": "https://{app-hostname}/.well-known/jwks.json",
+  "target_link_uri": "https://{app-hostname}/ltilaunch",
+  "oidc_initiation_url": "https://{app-hostname}/init/<uuid:lti-registration>/"
+}

--- a/setup/lti-config.json
+++ b/setup/lti-config.json
@@ -9,9 +9,10 @@
               "platform": "canvas.instructure.com",
               "placements": [
                   {
-                      "placement": "course_navigation",
-                      "message_type": "LtiResourceLinkRequest",
-                      "target_link_uri": "https://{app-hostname}/ltilaunch"
+                    "default": "disabled",  
+                    "placement": "course_navigation",
+                    "message_type": "LtiResourceLinkRequest",
+                    "target_link_uri": "https://{app-hostname}/ltilaunch"
                   }
               ]
           },


### PR DESCRIPTION
Fixes #2 

The PR completes
1. LTI launch workflow
2. Adding Django configuration for logging
3. LTI sample configuration file configuring from Platform/Canvas. Note: There is Tool Configuration at the both Platform/Tool level. This configuration I am addressing at Platform level. Also with CAI django-lti the LTI configuration is now done from Django Admin, making things little simpler. 
4. new Logging variables created at .env. So please update your .env. 