### PR TITLE
send LTI simplified data to Maizey endpoint (iss. #5)

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -6,11 +6,13 @@ MYSQL_PASSWORD=clrt_pwd
 MYSQL_HOST=clrt_mysql_host
 MYSQL_PORT=3306
 
-# Django settings
-# python manage.py shell -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())"
+#Django settings
 SECRET_KEY='you-django-key' 
 DJANGO_DEBUG=True
 DJANGO_LOG_LEVEL=DEBUG
 TZ=America/Detroit
 CSRF_TRUSTED_ORIGINS=https://*.instructure.com,https://*.umich.edu
 ALLOWED_HOSTS=.loophole.site,.ngrok-free.app, 127.0.0.1, localhost
+
+# grab from dropbox where all the secrets are stored
+MAIZEY_JWT_SECRET=secret

--- a/lti_redirect/maizey.py
+++ b/lti_redirect/maizey.py
@@ -1,0 +1,63 @@
+import jwt, logging, requests
+from decouple import config
+
+logger = logging.getLogger(__name__)
+
+class SendToMaizey():
+    
+    def __init__(self, lti_launch_data) -> None:
+        self.lti_launch_data = lti_launch_data
+        self.maizey_jwt_secret = config('MAIZEY_JWT_SECRET')
+        self.lti_custom_data = self.lti_launch_data['https://purl.imsglobal.org/spec/lti/claim/custom']
+    
+    def get_restructured_data(self):
+      course_title = self.lti_launch_data['https://purl.imsglobal.org/spec/lti/claim/context']['title']
+      lis = self.lti_launch_data['https://purl.imsglobal.org/spec/lti/claim/lis']
+
+      # Restructure the course info for Maizey needs
+      restructured_data = {
+      "canvas_url": self.lti_custom_data["canvas_url"],
+      "course": {
+          "id": self.lti_custom_data["course_id"],
+          "name": course_title,
+          "sis_id": lis["course_offering_sourcedid"],
+          "workflow_state": self.lti_custom_data["course_status"],
+          "enroll_status":self.lti_custom_data["course_enroll_status"]
+      },
+      "term": {
+          "id": self.lti_custom_data["term_id"],
+          "name": self.lti_custom_data["term_name"],
+          "term_start_date": self.lti_custom_data["term_start"],
+          "term_end_date": self.lti_custom_data["term_end"]
+      },
+      "user": {
+          "id": self.lti_custom_data["user_canvas_id"],
+          "login_id": self.lti_custom_data["login_id"],
+          "sis_id": lis["person_sourcedid"],
+          "roles": self.lti_custom_data["roles"].split(","),
+          "email_address": self.lti_launch_data["email"],
+          "name": self.lti_launch_data["name"],
+      } ,
+      "account": {
+          "id": self.lti_custom_data["course_canvas_account_id"],
+          "name": self.lti_custom_data["course_account_name"],
+          "sis_id": self.lti_custom_data["course_sis_account_id"]
+      }  
+      }
+      logger.info(f"Course data sending to Maizey endpoint: {restructured_data}")
+      return restructured_data
+
+    def send_to_maizey(self):
+       course_jwt = jwt.encode(self.get_restructured_data(), self.maizey_jwt_secret, algorithm='HS256')
+       maizey_url = f"{self.lti_custom_data['redirect_url']}t2/canvaslink?token={course_jwt}"
+       try:
+           response = requests.get(maizey_url)
+           response.raise_for_status()
+           # currently this is maizey url is retuning a HTML text
+           logger.info(f"Maizey response: {response.text}")
+           return True
+       except requests.exceptions.RequestException as e:
+            logger.error(f"Error sending course data to Maizey: {e}")
+            return False
+       
+        

--- a/lti_redirect/templates/home.html
+++ b/lti_redirect/templates/home.html
@@ -23,7 +23,7 @@
     {% endblock %}
     <hr/>
     <footer>
-        <p>&copy; 2023</p>
+        <p>&copy; 2024  The Regents of the University of Michigan</p>
     </footer>
 </div>
 </body>


### PR DESCRIPTION
Fixes #5 

The Maizey URL is part of the LTI custom Variables with key as `redirect_url`. I wasn't sure if they will create a endpoint based on the Canvas Campus code ( AA, Dearborn, Flint). So I am adding it to LTI custom. But this URL can be also coming from the .env. files

Currently the Maizey API response is not sending anything useful info. It is sending HTML text. 

Wrote some validation steps to verify if custom LTI variables are configured correctly. Since as of now we have a lot configured than usual since we don't have clear understanding what Maizey needs. 

**Config Change add Maizey JWT shared secret**

Launch data sending to Maizey Endpoint
```{'canvas_url': 'https://canvas-test.it.umich.edu', 'course': {'id': '403334', 'name': 'CCM Test Courses', 'sis_id': 'ccmC1626456-24', 'workflow_state': 'claimed', 'enroll_status': 'active'}, 'term': {'id': '27', 'name': 'Winter 2022', 'term_start_date': '2022-01-05T05:00:00Z', 'term_end_date': '2032-01-04T05:00:00Z'}, 'user': {'id': '99', 'login_id': 'pushyami', 'sis_id': '841', 'roles': ['TeacherEnrollment', 'Account Admin'], 'email_address': 'pushyami@umich.edu', 'name': 'Pushyami Gundala'}, 'account': {'id': '105', 'name': 'Practice Course Sub-Account', 'sis_id': 'ccmC16211556-24'}}```
