### PR TITLE
redirect users to Maizey endpoint (iss. #15)

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -29,10 +29,12 @@ SECRET_KEY = config('SECRET_KEY','123455')
 # Read the CSRF_TRUSTED_ORIGINS variable from the .env file
 csrf_trusted_origins = config('CSRF_TRUSTED_ORIGINS', '')
 CSRF_TRUSTED_ORIGINS = [origin.strip() for origin in csrf_trusted_origins.split(',')]
+print(os.path.join(BASE_DIR, "templates"))
 
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = config('DJANGO_DEBUG', default=False, cast=bool)
+print(f"DEBUG: {DEBUG} type: {type(DEBUG)}")
 RANDOM_PASSWORD_DEFAULT_LENGTH = 32
 
 allowed_hosts = config('ALLOWED_HOSTS', '')

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -29,12 +29,10 @@ SECRET_KEY = config('SECRET_KEY','123455')
 # Read the CSRF_TRUSTED_ORIGINS variable from the .env file
 csrf_trusted_origins = config('CSRF_TRUSTED_ORIGINS', '')
 CSRF_TRUSTED_ORIGINS = [origin.strip() for origin in csrf_trusted_origins.split(',')]
-print(os.path.join(BASE_DIR, "templates"))
 
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = config('DJANGO_DEBUG', default=False, cast=bool)
-print(f"DEBUG: {DEBUG} type: {type(DEBUG)}")
 RANDOM_PASSWORD_DEFAULT_LENGTH = 32
 
 allowed_hosts = config('ALLOWED_HOSTS', '')

--- a/lti_redirect/maizey.py
+++ b/lti_redirect/maizey.py
@@ -53,14 +53,15 @@ class SendToMaizey():
            return False
        course_jwt = jwt.encode(self.get_restructured_data(), self.maizey_jwt_secret, algorithm='HS256')
        maizey_url = f"{self.lti_custom_data['redirect_url']}t2/canvaslink?token={course_jwt}"
-       try:
-           response = requests.get(maizey_url)
-           response.raise_for_status()
-           # currently response from maizey endpoint upon success is retuning a HTML text
-           logger.info(f"Maizey response: {response.text}")
-           return True
-       except requests.exceptions.RequestException as e:
-            logger.error(f"Error sending course data to Maizey: {e}")
-            return False
+       return maizey_url
+    #    try:
+    #        response = requests.get(maizey_url)
+    #        response.raise_for_status()
+    #        # currently response from maizey endpoint upon success is retuning a HTML text
+    #        logger.info(f"Maizey response: {response.text}")
+    #        return True
+    #    except requests.exceptions.RequestException as e:
+    #         logger.error(f"Error sending course data to Maizey: {e}")
+    #         return False
        
         

--- a/lti_redirect/maizey.py
+++ b/lti_redirect/maizey.py
@@ -1,5 +1,6 @@
-import jwt, logging, requests
+import jwt, logging
 from decouple import config
+from jwt.exceptions import InvalidKeyError
 
 logger = logging.getLogger(__name__)
 
@@ -48,20 +49,13 @@ class SendToMaizey():
       return restructured_data
 
     def send_to_maizey(self):
+       maizey_url = None
        if not self.maizey_jwt_secret:
            logger.error("Maizey JWT secret is not configured")
-           return False
-       course_jwt = jwt.encode(self.get_restructured_data(), self.maizey_jwt_secret, algorithm='HS256')
-       maizey_url = f"{self.lti_custom_data['redirect_url']}t2/canvaslink?token={course_jwt}"
+       try:
+        course_jwt = jwt.encode(self.get_restructured_data(), self.maizey_jwt_secret, algorithm='HS256')
+        maizey_url = f"{self.lti_custom_data['redirect_url']}t2/canvaslink?token={course_jwt}"
+        logger.info(f"Maizey with course JWT URL: {maizey_url}")
+       except (InvalidKeyError,Exception) as e:
+           logger.error(f"Error encoding course data to JWT: {e}")
        return maizey_url
-    #    try:
-    #        response = requests.get(maizey_url)
-    #        response.raise_for_status()
-    #        # currently response from maizey endpoint upon success is retuning a HTML text
-    #        logger.info(f"Maizey response: {response.text}")
-    #        return True
-    #    except requests.exceptions.RequestException as e:
-    #         logger.error(f"Error sending course data to Maizey: {e}")
-    #         return False
-       
-        

--- a/lti_redirect/templates/home.html
+++ b/lti_redirect/templates/home.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" type="text/css" href="{% static 'home.css' %}"/>
     <script type=""text/javascript">
     window.onload = function() {
-        let maizey_url = "{{ maizey_url }}";
+        let maizey_url = "{{ maizey_url }}"
         if(maizey_url) {
             window.open(maizey_url, '_blank')
         }
@@ -28,9 +28,6 @@
 
 <div class="body-content">
     {% block content %}
-    {% if user.is_authenticated %}
-     <a href="{{ maizey_url }}" target="_blank">Maizey Redirect URL</a>
-    {% endif %}
     {% endblock %}
     <hr/>
     <footer>

--- a/lti_redirect/templates/home.html
+++ b/lti_redirect/templates/home.html
@@ -5,6 +5,14 @@
     <title>{% block title %}{% endblock %}</title>
     {% load static %}
     <link rel="stylesheet" type="text/css" href="{% static 'home.css' %}"/>
+    <script type=""text/javascript">
+    window.onload = function() {
+        let maizey_url = "{{ maizey_url }}";
+        if(maizey_url) {
+            window.open(maizey_url, '_blank')
+        }
+    }
+    </script>
 </head>
 
 <body>
@@ -20,6 +28,9 @@
 
 <div class="body-content">
     {% block content %}
+    {% if user.is_authenticated %}
+     <a href="{{ maizey_url }}" target="_blank">Maizey Redirect URL</a>
+    {% endif %}
     {% endblock %}
     <hr/>
     <footer>

--- a/lti_redirect/views.py
+++ b/lti_redirect/views.py
@@ -70,9 +70,16 @@ class ApplicationLaunchView(LtiLaunchBaseView):
             return redirect("error")
         if not login_user_from_lti(request, launch_data):
             return redirect("error")
-        if not SendToMaizey(launch_data).send_to_maizey():
-            return redirect("error")
-        return redirect("home")
+        maizey_url= SendToMaizey(launch_data).send_to_maizey()
+        logger.info(f"Maizey URL: {maizey_url}")
+        # logger.info(f"Course JWT: {course_jwt}")
+        context = {
+            "maizey_url": maizey_url,
+        }
+        # if not SendToMaizey(launch_data).send_to_maizey():
+        #     return redirect("error")
+        # return redirect("home")
+        return render(request, "home.html", context)
 
     def handle_deep_linking_launch(self, request, lti_launch):
         ...  # Optional.

--- a/lti_redirect/views.py
+++ b/lti_redirect/views.py
@@ -6,6 +6,7 @@ from django.shortcuts import redirect, render
 from lti_tool.views import LtiLaunchBaseView
 from django.contrib.auth.models import User
 from lti_redirect.maizey import SendToMaizey
+from django.http import HttpResponseRedirect
 
 logger = logging.getLogger(__name__)
 
@@ -70,16 +71,16 @@ class ApplicationLaunchView(LtiLaunchBaseView):
             return redirect("error")
         if not login_user_from_lti(request, launch_data):
             return redirect("error")
-        maizey_url= SendToMaizey(launch_data).send_to_maizey()
-        logger.info(f"Maizey URL: {maizey_url}")
-        # logger.info(f"Course JWT: {course_jwt}")
+        maizey_url = SendToMaizey(launch_data).send_to_maizey()
+        if not maizey_url:
+            return redirect("error")
         context = {
             "maizey_url": maizey_url,
         }
-        # if not SendToMaizey(launch_data).send_to_maizey():
-        #     return redirect("error")
-        # return redirect("home")
-        return render(request, "home.html", context)
+        if request.user.is_superuser:
+            return render(request, "home.html", context)
+        else:
+            return HttpResponseRedirect(maizey_url)
 
     def handle_deep_linking_launch(self, request, lti_launch):
         ...  # Optional.


### PR DESCRIPTION
Fixes #15

The users are now redirect to the Maizey endpoint for the LTI launch.

If the user is a super user then, user will be displayed home page so that they can have access to Django Admin view. Otherwise they will be redirected Maizey URL with JWT. 

Note: After implementing CSP the workflow with redirect might slightly change. 

**Input needed on this**: we could continue conversation in slack. But I want to start the conversation here. 
1. Also I am starting to think if we even needs to login every user who launched our redirect tool. Since goal for the ET team have the tool in front of all students in the coming Fall term. (So why do we need those user in Django table?)
2. We might at the least need to login the user who need Django admin console access. Who are mostly going to be TL-Dev. We could recognize then with one of the LTI custom Launch variable `is_root_account_user'

------------------------
Testing:
1. Test as user who has access to Django admin console
2. Test as Student or another role is fine as well. only thing is user role should not have a super user access.
