### PR TITLE
Fixes #17 - Implement Redis Caching

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -7,7 +7,7 @@ MYSQL_HOST=clrt_mysql_host
 MYSQL_PORT=3306
 
 # Redis settings
-REDIS_LOCATION=redis://clrt_redis_host:6379/1
+REDIS_LOCATION=redis://clrt_redis_host:6379
 
 #Django settings
 SECRET_KEY='your-django-key' 

--- a/.env.sample
+++ b/.env.sample
@@ -6,6 +6,9 @@ MYSQL_PASSWORD=clrt_pwd
 MYSQL_HOST=clrt_mysql_host
 MYSQL_PORT=3306
 
+# Redis settings
+REDIS_LOCATION=redis://clrt_redis_host:6379/1
+
 #Django settings
 SECRET_KEY='your-django-key' 
 DJANGO_DEBUG=True

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -159,11 +159,8 @@ DATABASES = {
 
 CACHES = {
     "default": {
-        "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": config('REDIS_LOCATION', "redis://clrt_redis_host:6379"),
-        "OPTIONS": {
-            "CLIENT_CLASS": "django_redis.client.DefaultClient",
-        }
+        "BACKEND": "django.core.cache.backends.redis.RedisCache",
+        "LOCATION": config('REDIS_LOCATION', "redis://clrt_redis_host:6379")
     }
 }
 

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -160,7 +160,7 @@ DATABASES = {
 CACHES = {
     "default": {
         "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": config('REDIS_LOCATION', "redis://127.0.0.1:6379/1"),
+        "LOCATION": config('REDIS_LOCATION', "redis://clrt_redis_host:6379"),
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
         }

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -157,15 +157,15 @@ DATABASES = {
     }
 }
 
-# This is needed to allow the LTI tool to work with the Django cache when running on multiple workers
 CACHES = {
     "default": {
-        "BACKEND": "django_mysql.cache.MySQLCache",
-        "LOCATION": "django_clrt_cache",
-        "KEY_PREFIX": "clrt",
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": config('REDIS_LOCATION', "redis://127.0.0.1:6379/1"),
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+        }
     }
 }
-
 
 # Password validation
 # https://docs.djangoproject.com/en/5.0/ref/settings/#auth-password-validators

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,8 +12,19 @@ services:
     ports:
       - "4306:3306"
     volumes:
-       - ./.data/mysql:/var/lib/mysql
+      - clrt-mysql-data:/var/lib/mysql
     container_name: clrt_mysql_host
+
+  redis:
+    image: redis:7
+    command: redis-server --stop-writes-on-bgsave-error no --save ""
+    # This is to simulate an Openshift container with no write permission except to /tmp
+    read_only: true
+    tmpfs:
+        - /tmp
+    volumes:
+        - clrt-redis-data:/data:ro
+    container_name: clrt_redis_host
 
   web:
     build: 
@@ -31,3 +42,7 @@ services:
     env_file:
       - .env
     container_name: clrt_web
+
+volumes:
+  clrt-mysql-data:
+  clrt-redis-data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,7 +12,7 @@ services:
     ports:
       - "4306:3306"
     volumes:
-      - clrt-mysql-data:/var/lib/mysql
+      - ./.data/mysql:/var/lib/mysql
     container_name: clrt_mysql_host
 
   redis:
@@ -44,5 +44,4 @@ services:
     container_name: clrt_web
 
 volumes:
-  clrt-mysql-data:
   clrt-redis-data:

--- a/lti_redirect/migrations/0002_drop_mysql_cache.py
+++ b/lti_redirect/migrations/0002_drop_mysql_cache.py
@@ -1,0 +1,13 @@
+from django.db import migrations
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('lti_redirect', '0001_mysql_cache'),  # Ensure this is the correct dependency
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql="DROP TABLE IF EXISTS django_clrt_cache;",
+        ),
+    ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,3 @@ django-mysql==4.14.0
 gunicorn==22.0.0
 whitenoise==6.7.0
 debugpy==1.8.2
-django-redis==5.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ django-mysql==4.14.0
 gunicorn==22.0.0
 whitenoise==6.7.0
 debugpy==1.8.2
+django-redis==5.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ django-mysql==4.14.0
 gunicorn==22.0.0
 whitenoise==6.7.0
 debugpy==1.8.2
+redis==5.0.7


### PR DESCRIPTION
Also moves the MySQL volume into Docker

You need the setting REDIS_LOCATION in your .env which the value in .env.sample works.

To test this do this when it's running, this will set and get from the cache.

```
docker exec -it clrt_web /code/manage.py shell

Python 3.10.14 (main, Jul  2 2024, 22:12:36) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
(InteractiveConsole)
>>> from django.core.cache import cache; cache.set('test_key', 'test_value', timeout=60);cache.get('test_key')
True
'test_value'
```