### PR TITLE
#31 sending if canvas user is Proxied user or not in course payload

### DIFF
--- a/lti_redirect/maizey.py
+++ b/lti_redirect/maizey.py
@@ -2,7 +2,6 @@ from datetime import datetime, timedelta, timezone
 import jwt, logging
 from decouple import config
 from jwt.exceptions import InvalidKeyError
-from lti_redirect.utils.utils import check_email_parameter
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +23,7 @@ class SendToMaizey():
       "course": {
           "id": self.lti_custom_data["course_id"],
           "name": course_title,
-          "sis_id": lis["course_offering_sourcedid"],
+          "sis_id": lis.get("course_offering_sourcedid"),
           "workflow_state": self.lti_custom_data["course_status"],
           "enroll_status":self.lti_custom_data["course_enroll_status"]
       },
@@ -37,9 +36,9 @@ class SendToMaizey():
       "user": {
           "id": self.lti_custom_data["user_canvas_id"],
           "login_id": self.lti_custom_data["login_id"],
-          "sis_id": lis["person_sourcedid"],
+          "sis_id": lis.get("person_sourcedid"),
           "roles": self.lti_custom_data["roles"].split(","),
-          "email_address": check_email_parameter(self.lti_launch_data),
+          "email_address": self.lti_launch_data.get("email"),
           "name": self.lti_launch_data["name"],
           "is_proxied_user": self.lti_custom_data["masquerade_user_canvas_id"].isdigit() 
       } ,

--- a/lti_redirect/utils/utils.py
+++ b/lti_redirect/utils/utils.py
@@ -1,4 +1,0 @@
-def check_email_parameter(launch_data):
-    if "email" in launch_data:
-        return launch_data["email"]
-    return None

--- a/lti_redirect/utils/utils.py
+++ b/lti_redirect/utils/utils.py
@@ -1,0 +1,4 @@
+def check_email_parameter(launch_data):
+    if "email" in launch_data:
+        return launch_data["email"]
+    return None

--- a/lti_redirect/views.py
+++ b/lti_redirect/views.py
@@ -7,7 +7,6 @@ from lti_tool.views import LtiLaunchBaseView
 from django.contrib.auth.models import User
 from lti_redirect.maizey import SendToMaizey
 from django.http import HttpResponseRedirect
-from lti_redirect.utils.utils import check_email_parameter
 
 logger = logging.getLogger(__name__)
 
@@ -39,9 +38,9 @@ def validate_custom_lti_launch_data(lti_launch):
 
 def login_user_from_lti(request, launch_data):
     try:
-        first_name = launch_data['given_name']
-        last_name = launch_data['family_name']
-        email = check_email_parameter(launch_data)
+        first_name = launch_data.get('given_name')
+        last_name = launch_data.get('family_name')
+        email = launch_data.get('email')
         username = launch_data['https://purl.imsglobal.org/spec/lti/claim/custom']['login_id']
         logger.info(f'the user {first_name} {last_name} {email} {username} launch the tool')
         user_obj = User.objects.get(username=username)

--- a/lti_redirect/views.py
+++ b/lti_redirect/views.py
@@ -7,6 +7,7 @@ from lti_tool.views import LtiLaunchBaseView
 from django.contrib.auth.models import User
 from lti_redirect.maizey import SendToMaizey
 from django.http import HttpResponseRedirect
+from lti_redirect.utils.utils import check_email_parameter
 
 logger = logging.getLogger(__name__)
 
@@ -22,7 +23,7 @@ def validate_custom_lti_launch_data(lti_launch):
     "roles", "term_id", "login_id", "term_end", "course_id", "term_name", "canvas_url", 
     "term_start", "redirect_url", "course_status", "user_canvas_id", 
     "course_account_name", "course_enroll_status", "course_sis_account_id", 
-    "course_canvas_account_id"]
+    "course_canvas_account_id", 'masquerade_user_canvas_id' ]
     main_key = "https://purl.imsglobal.org/spec/lti/claim/custom"
     if main_key not in lti_launch:
         logger.error(f"LTI custom '{main_key}' variables are not configured")
@@ -40,7 +41,7 @@ def login_user_from_lti(request, launch_data):
     try:
         first_name = launch_data['given_name']
         last_name = launch_data['family_name']
-        email = launch_data['email']
+        email = check_email_parameter(launch_data)
         username = launch_data['https://purl.imsglobal.org/spec/lti/claim/custom']['login_id']
         logger.info(f'the user {first_name} {last_name} {email} {username} launch the tool')
         user_obj = User.objects.get(username=username)

--- a/setup/lti-config.json
+++ b/setup/lti-config.json
@@ -31,13 +31,14 @@
       "term_name": "$Canvas.term.name",
       "canvas_url": "$Canvas.api.baseUrl",
       "term_start": "$Canvas.term.startAt",
-      "redirect_url": "https://dev2.dev.umgpt.umich.edu/",
+      "redirect_url": "https://main.dev.umgpt.umich.edu/",
       "course_status": "$Canvas.course.workflowState",
       "user_canvas_id": "$Canvas.user.id",
       "course_account_name": "$Canvas.account.name",
       "course_enroll_status": "$Canvas.enrollment.enrollmentState",
       "course_sis_account_id": "$Canvas.course.sisSourceId",
-      "course_canvas_account_id": "$Canvas.account.id"
+      "course_canvas_account_id": "$Canvas.account.id",
+      "masquerade_user_canvas_id": "$Canvas.masqueradingUser.id"
   },
   "public_jwk_url": "https://{app-hostname}/.well-known/jwks.json",
   "target_link_uri": "https://{app-hostname}/ltilaunch",


### PR DESCRIPTION
Fixes #31 

If the user is masqueraded as below use cases we will set `is_proxied_user` is set to true/false. 
1.  Canvas Root account admin 
2. View as Student ( for course admins like instructors, TA's)

[Canvas LTI variable substitution](https://canvas.instructure.com/doc/api/file.tools_variable_substitutions.html) provide Canvas user ID via 'Canvas.masqueradingUser.id' to tell who is the user masquerading as. The value is provided as String integer. If the user is not masquerading then LTI launch simply returns `$Canvas.masqueradingUser.id`. 

Use Case to test:
1. Test as you, expected `is_proxied_user = false`
2. Becoming another user, expected `is_proxied_user = true`
3. View as student (In a course from top right hand ), expected `is_proxied_user = true`
![Screenshot 2024-09-03 at 3 42 21 PM](https://github.com/user-attachments/assets/5fddb651-8e43-47cd-9475-80074fe48337)

Based on the value Maizey will show necessary message to user
( Look for this Course Payload in Django Logs or Browser dev tools (Alt + CMD + I) --> Network Tab --> Maizey Redirect `t2/canvaslink?token= {}` )
